### PR TITLE
esp32: Disable LAN by default.

### DIFF
--- a/ports/esp32/modnetwork.c
+++ b/ports/esp32/modnetwork.c
@@ -546,7 +546,9 @@ STATIC const mp_rom_map_elem_t mp_module_network_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_network) },
     { MP_OBJ_NEW_QSTR(MP_QSTR___init__), (mp_obj_t)&esp_initialize_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_WLAN), (mp_obj_t)&get_wlan_obj },
+#if MICROPY_PY_NETWORK_LAN
     { MP_OBJ_NEW_QSTR(MP_QSTR_LAN), (mp_obj_t)&get_lan_obj },
+#endif
     { MP_OBJ_NEW_QSTR(MP_QSTR_phy_mode), (mp_obj_t)&esp_phy_mode_obj },
 
 #if (MICROPY_ESP32_BLUETOOTH)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -141,6 +141,7 @@
 #define MICROPY_PY_USSL_FINALISER           (1)
 #define MICROPY_PY_WEBSOCKET                (0)
 #define MICROPY_PY_FRAMEBUF                 (1)
+#define MICROPY_PY_NETWORK_LAN              (0)
 
 // fatfs configuration
 #define MICROPY_FATFS_ENABLE_LFN            (1)


### PR DESCRIPTION
This saves 32kB of .bss data and 1808 bytes of .data.

I think it's best to keep it disabled by default, as I suspect more people will be interested in BT than in ethernet. Maybe it's possible to allocate these buffers on demand in the future, so that the RAM is only used when needed.