### PR TITLE
Allocate Bluetooth memory dynamically

### DIFF
--- a/ports/esp32/esp32.custom_common.ld
+++ b/ports/esp32/esp32.custom_common.ld
@@ -33,6 +33,7 @@ SECTIONS
     *rtc_wake_stub*.o(.bss .bss.*)
     *rtc_wake_stub*.o(COMMON)
     _rtc_bss_end = ABSOLUTE(.);
+    *(.rtc_enable_bluetooth)
   } > rtc_slow_seg
 
   /* Send .iram0 code to iram */
@@ -104,6 +105,7 @@ SECTIONS
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
+    *(.mp_task_heap)
     *(.data)
     *(.data.*)
     *(.gnu.linkonce.d.*)

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -48,16 +48,27 @@
 #include "uart.h"
 #include "modmachine.h"
 #include "mpthreadport.h"
+#include "rom/rtc.h"
 
 // MicroPython runs as a task under FreeRTOS
 #define MP_TASK_PRIORITY        (ESP_TASK_PRIO_MIN + 1)
 #define MP_TASK_STACK_SIZE      (16 * 1024)
 #define MP_TASK_STACK_LEN       (MP_TASK_STACK_SIZE / sizeof(StackType_t))
-#define MP_TASK_HEAP_SIZE       (10 * 1024)
+#define MP_TASK_HEAP_SIZE       (96 * 1024)
 
 STATIC StaticTask_t mp_task_tcb;
 STATIC StackType_t mp_task_stack[MP_TASK_STACK_LEN] __attribute__((aligned (8)));
-STATIC uint8_t mp_task_heap[MP_TASK_HEAP_SIZE];
+
+// Allocate an area of memory at the start of DRAM, right behind the 64kB
+// Bluetooth area (if enabled).
+__attribute__((section(".mp_task_heap")))
+STATIC uint8_t mp_task_heap[MP_TASK_HEAP_SIZE - CONFIG_BT_RESERVE_DRAM];
+
+#if CONFIG_BT_ENABLED
+bool bluetooth_enabled;
+__attribute__((section(".rtc_enable_bluetooth")))
+bool rtc_enable_bluetooth;
+#endif
 
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
@@ -66,11 +77,28 @@ void mp_task(void *pvParameter) {
     #endif
     uart_init();
 
+    if (rtc_get_reset_reason(0) == POWERON_RESET) {
+        // Initialize the flag whether BT is in use.
+        rtc_enable_bluetooth = false;
+    }
+
 soft_reset:
     // initialise the stack pointer for the main thread
     mp_stack_set_top((void *)sp);
     mp_stack_set_limit(MP_TASK_STACK_SIZE - 1024);
+#if CONFIG_BT_ENABLED
+    bluetooth_enabled = rtc_enable_bluetooth;
+    if (rtc_enable_bluetooth) {
+        // Use only mp_task_heap as heap, leave Bluetooth area alone.
+        gc_init(mp_task_heap, mp_task_heap + sizeof(mp_task_heap));
+    } else {
+        // Use BT area and mp_task_heap area as heap.
+        uint32_t heap_start = (uint32_t)mp_task_heap; // work around the (normally legit!) -Werror=array-bounds
+        gc_init((uint8_t*)heap_start - CONFIG_BT_RESERVE_DRAM, mp_task_heap + sizeof(mp_task_heap));
+    }
+#else
     gc_init(mp_task_heap, mp_task_heap + sizeof(mp_task_heap));
+#endif
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
@@ -111,6 +139,7 @@ soft_reset:
 
     mp_deinit();
     fflush(stdout);
+    rtc_enable_bluetooth = bluetooth_enabled;
     goto soft_reset;
 }
 

--- a/ports/esp32/modesp.c
+++ b/ports/esp32/modesp.c
@@ -95,6 +95,15 @@ STATIC mp_obj_t esp_gpio_matrix_out(size_t n_args, const mp_obj_t *args) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_gpio_matrix_out_obj, 4, 4, esp_gpio_matrix_out);
 
+#if CONFIG_BT_ENABLED
+extern bool rtc_enable_bluetooth;
+STATIC mp_obj_t esp_bluetooth_allocate_memory(mp_obj_t allocate) {
+    rtc_enable_bluetooth = mp_obj_is_true(allocate);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(esp_bluetooth_allocate_memory_obj, esp_bluetooth_allocate_memory);
+#endif
+
 STATIC mp_obj_t esp_neopixel_write_(mp_obj_t pin, mp_obj_t buf, mp_obj_t timing) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
@@ -115,6 +124,8 @@ STATIC const mp_rom_map_elem_t esp_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_gpio_matrix_in), MP_ROM_PTR(&esp_gpio_matrix_in_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_matrix_out), MP_ROM_PTR(&esp_gpio_matrix_out_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_bluetooth_allocate_memory), MP_ROM_PTR(&esp_bluetooth_allocate_memory_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_neopixel_write), MP_ROM_PTR(&esp_neopixel_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_dht_readinto), MP_ROM_PTR(&dht_readinto_obj) },

--- a/ports/esp32/network_bt.c
+++ b/ports/esp32/network_bt.c
@@ -45,6 +45,7 @@
 #include "esp_gatts_api.h"
 #include "esp_gattc_api.h"
 
+extern bool bluetooth_enabled;
 
 #define CALLBACK_QUEUE_SIZE 10
 
@@ -378,6 +379,10 @@ STATIC void network_bt_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 
 STATIC mp_obj_t network_bt_init(mp_obj_t self_in) {
     network_bt_obj_t * self = (network_bt_obj_t*)self_in;
+
+    if (!bluetooth_enabled) {
+        mp_raise_msg(&mp_type_MemoryError, "Bluetooth memory not allocated");
+    }
 
     if (item_mut == NULL) {
         item_mut = xSemaphoreCreateMutex();


### PR DESCRIPTION
I managed to allocate an area at the start of DRAM0 for the MicroPython heap - right behind the BT memory area. This way, it is possible to select at runtime whether to enable BT with reduced heap, or use the full heap without BT. For example, using the following flow:

```python
import network, esp, machine

try:
    bt = network.Bluetooth()
except MemoryError:
    # BT memory hasn't been reserved yet.
    # Set a flag in RTC memory that BT should be enabled at start.
    esp.bluetooth_allocate_memory(True)
    # Reset, BT memory will be enabled on next boot
    machine.reset()
    # unreachable

# Bluetooth has been enabled, use it
bt.ble_adv_enable(True)
# etc
```

Reasons to go for this method:
* GC heap is allocated once at startup, and cannot be changed later.
* BT memory is only valid after a reset.
* GC heap must be contiguous and BT memory has a fixed location, so the heap must be right after the BT memory area.
* Bluetooth memory is only used when necessary. Scripts that don't use Bluetooth will use all memory without doing anything special. Scripts that are written for pre-BT esp32 or for another MCU won't have to be ported to this chip to use more than 32kB heap.

Note that `machine.reset()` currently crashes (see https://github.com/micropython/micropython-esp32/issues/110) but it still works.